### PR TITLE
Added submitted mixin to schemas missing it

### DIFF
--- a/src/encoded/schemas/award.json
+++ b/src/encoded/schemas/award.json
@@ -7,6 +7,7 @@
     "additionalProperties": false,
     "mixinProperties": [
         { "$ref": "mixins.json#/schema_version" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/uuid" }
     ],
     "type": "object",

--- a/src/encoded/schemas/biosource.json
+++ b/src/encoded/schemas/biosource.json
@@ -15,6 +15,7 @@
         { "$ref": "mixins.json#/accession" },
         { "$ref": "mixins.json#/attribution" },
         { "$ref": "mixins.json#/references" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/notes" }
     ],
     "properties": {

--- a/src/encoded/schemas/construct.json
+++ b/src/encoded/schemas/construct.json
@@ -15,6 +15,7 @@
         { "$ref": "mixins.json#/attribution" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/documents" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/notes" }
     ],
     "properties": {

--- a/src/encoded/schemas/lab.json
+++ b/src/encoded/schemas/lab.json
@@ -9,6 +9,7 @@
     "mixinProperties": [
         { "$ref": "mixins.json#/schema_version" },
         { "$ref": "mixins.json#/uuid" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/status" }
     ],
     "properties": {

--- a/src/encoded/schemas/modification.json
+++ b/src/encoded/schemas/modification.json
@@ -14,6 +14,7 @@
         { "$ref": "mixins.json#/status" },
         { "$ref": "mixins.json#/attribution" },
         { "$ref": "mixins.json#/references" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/notes" }
     ],
     "properties": {

--- a/src/encoded/schemas/organism.json
+++ b/src/encoded/schemas/organism.json
@@ -8,6 +8,7 @@
     "additionalProperties": false,
     "mixinProperties": [
         { "$ref": "mixins.json#/schema_version" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/uuid" }
     ],
     "properties": {

--- a/src/encoded/schemas/quality_metric.json
+++ b/src/encoded/schemas/quality_metric.json
@@ -9,7 +9,8 @@
     "mixinProperties": [
         { "$ref": "mixins.json#/schema_version" },
         { "$ref": "mixins.json#/uuid" },
-        { "$ref": "mixins.json#/aliases" },        
+        { "$ref": "mixins.json#/aliases" },
+        { "$ref": "mixins.json#/submitted" },        
         { "$ref": "mixins.json#/status" }
    ],
     "properties": {

--- a/src/encoded/schemas/quality_metric_fastqc.json
+++ b/src/encoded/schemas/quality_metric_fastqc.json
@@ -11,6 +11,7 @@
         { "$ref": "quality_metric.json#/properties" },
         { "$ref": "mixins.json#/uuid" },
         { "$ref": "mixins.json#/aliases" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/status" }
    ],
     "properties": {

--- a/src/encoded/schemas/quality_metric_flag.json
+++ b/src/encoded/schemas/quality_metric_flag.json
@@ -10,6 +10,7 @@
         { "$ref": "mixins.json#/schema_version" },
         { "$ref": "mixins.json#/uuid" },
         { "$ref": "mixins.json#/status" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/attachment" }
    ],
     "properties": {

--- a/src/encoded/schemas/software.json
+++ b/src/encoded/schemas/software.json
@@ -14,6 +14,7 @@
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/status" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/attribution" }
     ],
     "properties": {

--- a/src/encoded/schemas/summary_statistic.json
+++ b/src/encoded/schemas/summary_statistic.json
@@ -9,6 +9,7 @@
     "mixinProperties": [
         { "$ref": "mixins.json#/schema_version" },
         { "$ref": "mixins.json#/uuid" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/status" }
    ],
     "properties": {

--- a/src/encoded/schemas/summary_statistic_hic.json
+++ b/src/encoded/schemas/summary_statistic_hic.json
@@ -10,6 +10,7 @@
         { "$ref": "summary_statistic.json#/properties" },
         { "$ref": "mixins.json#/schema_version" },
         { "$ref": "mixins.json#/status" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/uuid" }
    ],
     "properties": {

--- a/src/encoded/schemas/treatment.json
+++ b/src/encoded/schemas/treatment.json
@@ -15,6 +15,7 @@
         { "$ref": "mixins.json#/attribution" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/notes" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/documents" }
     ],
     "properties": {

--- a/src/encoded/schemas/treatment_chemical.json
+++ b/src/encoded/schemas/treatment_chemical.json
@@ -16,6 +16,7 @@
         { "$ref": "mixins.json#/attribution" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/notes" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/documents" }
     ],
     "properties": {

--- a/src/encoded/schemas/treatment_rnai.json
+++ b/src/encoded/schemas/treatment_rnai.json
@@ -16,6 +16,7 @@
         { "$ref": "mixins.json#/attribution" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/notes" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/documents" }
     ],
     "properties": {

--- a/src/encoded/schemas/user.json
+++ b/src/encoded/schemas/user.json
@@ -10,6 +10,7 @@
         { "$ref": "mixins.json#/schema_version" },
         { "$ref": "mixins.json#/uuid" },
         { "$ref": "mixins.json#/aliases" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/status" }
     ],
     "properties": {

--- a/src/encoded/schemas/vendor.json
+++ b/src/encoded/schemas/vendor.json
@@ -12,6 +12,7 @@
         { "$ref": "mixins.json#/uuid" },
         { "$ref": "mixins.json#/status" },
         { "$ref": "mixins.json#/notes" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/aliases" }
     ],
     "properties": {

--- a/src/encoded/schemas/workflow_run.json
+++ b/src/encoded/schemas/workflow_run.json
@@ -13,6 +13,7 @@
         { "$ref": "mixins.json#/uuid" },
         { "$ref": "mixins.json#/documents" },
         { "$ref": "mixins.json#/attribution" },
+        { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/notes"}
     ],
     "properties": {


### PR DESCRIPTION
Added the submitted mixin to the following schemas:
award, biosource, construct, quality_metric*, software, summary_statistic*, treatment*, user, vendor and workflow_run.

Will separately add to the new schema in the add_capture_hic branch.