### PR TITLE
Exporting Experiment (Sub-)Table into own file & component

### DIFF
--- a/src/encoded/static/components/browse.js
+++ b/src/encoded/static/components/browse.js
@@ -51,7 +51,7 @@ var IndeterminateCheckbox = React.createClass({
     }
 });
 
-var ExperimentSet = module.exports.ExperimentSet = React.createClass({
+var ExperimentSetRow = module.exports.ExperimentSetRow = React.createClass({
     getInitialState: function() {
     	return {
             open: false,
@@ -813,7 +813,7 @@ var ColumnSorter = React.createClass({
 var ResultTable = browse.ResultTable = React.createClass({
 
     getInitialState: function(){
-        return{
+        return {
             sortColumn: null,
             sortReverse: false
         }
@@ -827,12 +827,12 @@ var ResultTable = browse.ResultTable = React.createClass({
     },
 
     sortBy: function(key, reverse) {
-        if(reverse){
+        if (reverse) {
             this.setState({
                 sortColumn: key,
                 sortReverse: !this.state.sortReverse
             });
-        }else{
+        } else {
             this.setState({
                 sortColumn: key,
                 sortReverse: false
@@ -843,6 +843,7 @@ var ResultTable = browse.ResultTable = React.createClass({
 
     render: function() {
         var context = this.props.context;
+        console.log(context);
         var results = context['@graph'];
         var resultCount = results.length; // account for empty expt sets
         // use first experiment set to grap type (all types are the same in any given graph)
@@ -909,7 +910,7 @@ var ResultTable = browse.ResultTable = React.createClass({
             var columns = {};
             var addInfo = {};
             var firstExp = experimentArray[0]; // use only for biological replicates
-            for (var i=0; i<Object.keys(columnTemplate).length;i++){
+            for (var i=0; i<Object.keys(columnTemplate).length;i++) {
                 if(Object.keys(columnTemplate)[i] === 'Exps'){
                     columns[Object.keys(columnTemplate)[i]] = experimentArray.length;
                     continue;
@@ -937,7 +938,18 @@ var ResultTable = browse.ResultTable = React.createClass({
                 if(sortColumn){
                     keyVal = columns[sortColumn];
                 }
-                resultListing.push(<ExperimentSet addInfo={addInfo} columns={columns} expSetFilters={expSetFilters} targetFiles={targetFiles} href={href} experimentArray={experimentArray} passExperiments={intersection} key={keyVal+href} />);
+                resultListing.push(
+                    <ExperimentSetRow 
+                        addInfo={addInfo} 
+                        columns={columns} 
+                        expSetFilters={expSetFilters} 
+                        targetFiles={targetFiles} 
+                        href={href} 
+                        experimentArray={experimentArray} 
+                        passExperiments={intersection}
+                        key={keyVal+href} 
+                    />
+                );
             }
         });
         if(sortColumn){

--- a/src/encoded/static/components/experiments-table.js
+++ b/src/encoded/static/components/experiments-table.js
@@ -1,0 +1,343 @@
+var React = require('react');
+var Table = require('react-bootstrap').Table;
+var Checkbox = require('react-bootstrap').Checkbox;
+var _ = require('underscore');
+
+/**
+ * To be used within Experiments Set View/Page, or
+ * within a collapsible row on the browse page.
+ * 
+ * Shows experiments only, not experiment sets.
+ * 
+ * Allows either table component itself to control state of "selectedFiles"
+ * or for a parentController (passed in as a prop) to take over management
+ * of "selectedFiles" Set and "checked", for integration with other pages/UI.
+ */
+
+var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
+
+    propTypes : {
+        columnHeaders : React.PropTypes.array.isRequired,
+        passExperiments : React.PropTypes.instanceOf(Set),
+        experimentArray : React.PropTypes.array,
+        parentController : function(props, propName, componentName){
+            // Custom validation
+            if (props[propName] && 
+                (typeof props[propName].state.checked != 'boolean' || !(props[propName].state.selectedFiles instanceof Set))
+            ){
+                return new Error('parentController must be a React Component passed in as "this", with "selectedFiles" (Set) and "checked" (bool) in its state.');
+            } 
+        }
+    },
+
+    getInitialState: function() {
+    	return {
+            checked: true,
+            selectedFiles: new Set()
+        };
+    },
+
+    handleFileUpdate: function (uuid, add=true){
+        var newSet = this.state.selectedFiles;
+        
+        if(add){
+            if(!newSet.has(uuid)){
+                newSet.add(uuid);
+            }
+        } else if (newSet.has(uuid)) {
+            newSet.delete(uuid);
+        }
+
+        if (!this.props.parentController){
+            // Set state on self if no parent controller
+            this.setState({
+                selectedFiles: newSet
+            });
+        } else {
+            this.props.parentController.setState({
+                selectedFiles: newSet
+            });
+        }
+        
+    },
+
+    getFileDetailContainer : function(){
+        // Re-use if passed in by a parent as a prop, 
+        // otherwise generate from experimentArray & passExperiments props.
+        if (this.props.fileDetailContainer) return this.props.fileDetailContainer; 
+        return getFileDetailContainer(this.props.experimentArray, this.props.passExperiments);
+    },
+
+    render : function(){
+        var fileDetailContainer = this.getFileDetailContainer();
+        var fileDetail = fileDetailContainer.fileDetail;
+        var emptyExps = fileDetailContainer.emptyExps;
+
+        var formattedColumnHeaders = this.props.columnHeaders.map(function(columnTitle, i){
+            return <th className="text-500" key={i}>{ columnTitle }</th>;
+        });
+
+        // Let parentController control 'checked' state if provided.
+        // Fallback to own state otherwise.
+        if (this.props.parentController) {
+            var checked = this.props.parentController.state.checked;
+        } else {
+            var checked = this.state.checked;
+        }
+
+        var childFileEntryRows = Object.keys(fileDetail).map(function (file) {
+            return (
+                <FileEntry 
+                    expSetFilters={this.props.expSetFilters} 
+                    info={fileDetail[file]} 
+                    key={fileDetail[file]['uuid'] + file} 
+                    parentChecked={checked} 
+                    handleFileUpdate={this.handleFileUpdate}
+                />
+            );
+        }.bind(this));
+
+        // sort to group experiments
+        childFileEntryRows.sort(function(a,b){
+            return(a.key - b.key);
+        });
+
+        return (
+            <Table className="expset-table" striped bordered condensed hover>
+                <thead>
+                    <tr>
+                        { formattedColumnHeaders }
+                    </tr>
+                </thead>
+                { childFileEntryRows }
+            </Table>
+        );
+    }
+
+});
+
+/**
+ * Returns an object containing fileDetail and emptyExps.
+ */
+
+var getFileDetailContainer = module.exports.getFileDetailContainer = function(experimentArray, passedExperiments){
+
+    var fileDetail = {}; //use @id field as key
+    var emptyExps = [];
+
+    for (var i=0; i<experimentArray.length; i++){
+        if(passedExperiments.has(experimentArray[i])){
+            var tempFiles = [];
+            var biosample_accession = experimentArray[i].biosample ? experimentArray[i].biosample.accession : null;
+            var biosample_id = biosample_accession ? experimentArray[i].biosample['@id'] : null;
+
+            var experimentDetails = {
+                'accession':    experimentArray[i].accession,
+                'biosample':    biosample_accession,
+                'biosample_id': biosample_id,
+                'uuid':         experimentArray[i].uuid,
+                '@id' :         experimentArray[i]['@id']
+                // Still missing : 'data', 'related'
+            }
+
+            if(experimentArray[i].files){
+                tempFiles = experimentArray[i].files;
+            } else if (experimentArray[i].filesets) {
+                for (var j=0; j<experimentArray[i].filesets.length; j++) {
+                    if (experimentArray[i].filesets[j].files_in_set) {
+                        tempFiles = tempFiles.concat(experimentArray[i].filesets[j].files_in_set);
+                    }
+                }
+            // No files in experiment
+            } else {
+                emptyExps.push(experimentArray[i]['@id']);
+                experimentDetails.data = {};
+                fileDetail[experimentArray[i]['@id']] = experimentDetails;
+                continue;
+            }
+
+            // save appropriate experiment info
+            if(tempFiles.length > 0){
+                var relatedFiles = {};
+                var relatedData = [];
+                for(var k=0;k<tempFiles.length;k++){
+
+                    // only use first file relation for now. Only support one relationship total
+                    if(tempFiles[k].related_files && tempFiles[k].related_files[0].file){
+                        // in form [related file @id, this file @id]
+                        relatedFiles[tempFiles[k].related_files[0].file] =  tempFiles[k]['@id'];
+                        fileDetail[tempFiles[k]['@id']] = _.extend({
+                            'data' : tempFiles[k],
+                            'related' : {
+                                'relationship_type':tempFiles[k].related_files[0].relationship_type,
+                                'file':tempFiles[k].related_files[0].file,
+                                'data':null
+                            }
+                        }, experimentDetails);
+                    } else {
+                        fileDetail[tempFiles[k]['@id']] = _.extend({
+                            'data' : tempFiles[k]
+                        }, experimentDetails);
+                    }
+                }
+                var usedRelations = [];
+                for(var k=0;k<tempFiles.length;k++){
+                    if(_.contains(Object.keys(relatedFiles), tempFiles[k]['@id'])){
+                        if(_.contains(usedRelations, tempFiles[k]['@id'])){
+                            // skip already-added related files
+                            delete fileDetail[relatedFiles[tempFiles[k]['@id']]];
+                        }else{
+                            fileDetail[relatedFiles[tempFiles[k]['@id']]]['related']['data'] = tempFiles[k];
+                            usedRelations.push(relatedFiles[tempFiles[k]['@id']]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return { 'fileDetail' : fileDetail, 'emptyExps' : emptyExps };
+}
+
+
+var FileEntry = React.createClass({
+
+    getInitialState: function() {
+        return {
+            checked: true
+        };
+    },
+
+    // initial checkbox setting
+    componentWillMount: function(){
+        // if(this.props.exptPassed && _.contains(this.props.filteredFiles, this.props.file.uuid)){
+        //     this.setState({
+        //         checked: true
+        //     });
+        // }
+        if(this.props.info.data){
+            this.props.handleFileUpdate(this.props.info.data.uuid, true);
+        }
+    },
+
+    // update checkboxes if parent has changed
+    componentWillReceiveProps: function(nextProps) {
+        // if(this.props.filteredFiles !== nextProps.filteredFiles || this.props.exptPassed !== nextProps.exptPassed){
+        //     if(nextProps.exptPassed && _.contains(nextProps.filteredFiles, this.props.file.uuid)){
+        //         this.setState({
+        //             checked: true
+        //         });
+        //     }
+        // }
+        if(this.props.parentChecked !== nextProps.parentChecked){
+            this.setState({
+                checked: nextProps.parentChecked
+            });
+        }
+    },
+
+    // update parent checked state
+    componentDidUpdate(nextProps, nextState){
+        if((nextState.checked !== this.state.checked || !_.isEqual(this.props.expSetFilters, nextProps.expSetFilters)) && this.props.info.data){
+            this.props.handleFileUpdate(this.props.info.data.uuid, this.state.checked);
+        }
+    },
+
+    handleCheck: function() {
+        this.setState({
+            checked: !this.state.checked
+        });
+    },
+
+    render: function(){
+        var file = this.props.info.data ? this.props.info.data : null;
+        var info = this.props.info;
+        var relationship = this.props.info.related ? this.props.info.related : null;
+        var relatedFile;
+        if(relationship){
+            relatedFile = this.props.info.related.data ? this.props.info.related.data : null;
+        }
+        var fileOne;
+        var fileTwo;
+        var fileID;
+        // code embarrasingly specific to fastq file pairs
+        if(file){
+            if(file.paired_end && file.paired_end === '1'){
+                fileOne = [];
+                fileOne.push(<td><a href={file['@id'] || ''}>{file.accession || file.uuid || file['@id']}</a></td>);
+                fileOne.push(<td>{file.file_format}</td>);
+                fileOne.push(<td>Paired end {file.paired_end}</td>);
+            }else if(file.paired_end && file.paired_end === '2'){
+                fileTwo = [];
+                fileTwo.push(<td><a href={file['@id'] || ''}>{file.accession || file.uuid || file['@id']}</a></td>);
+                fileTwo.push(<td>{file.file_format}</td>);
+                fileTwo.push(<td>Paired end {file.paired_end}</td>);
+            }else{
+                fileOne = [];
+                if(file['@id']){
+                    fileOne.push(<td><a href={file['@id'] || ''}>{file.accession || file.uuid || file['@id']}</a></td>);
+                    fileOne.push(<td>{file.file_format}</td>);
+                    fileOne.push(<td>{(file.file_format === 'fastq' || file.file_format === 'fasta') ? 'Unpaired' : ''}</td>);
+                }else{
+                    fileOne.push(<td>No files</td>);
+                    fileOne.push(<td></td>);
+                    fileOne.push(<td></td>);
+                }
+            }
+            fileID = this.state.checked + "~" + true + "~" + file.file_format + "~" + file.uuid;
+        }
+        if(relatedFile){
+            if(relatedFile.paired_end && relatedFile.paired_end === '1'){
+                fileOne = [];
+                fileOne.push(<td><a href={relatedFile['@id'] || ''}>{relatedFile.accession || relatedFile.uuid || relatedFile['@id']}</a></td>);
+                fileOne.push(<td>{relatedFile.file_format}</td>);
+                fileOne.push(<td>Paired end {relatedFile.paired_end}</td>);
+            }else if(relatedFile.paired_end && relatedFile.paired_end === '2'){
+                fileTwo = [];
+                fileTwo.push(<td><a href={relatedFile['@id'] || ''}>{relatedFile.accession || relatedFile.uuid || relatedFile['@id']}</a></td>);
+                fileTwo.push(<td>{relatedFile.file_format}</td>);
+                fileTwo.push(<td>Paired end {relatedFile.paired_end}</td>);
+            }else{
+                fileTwo = [];
+                fileTwo.push(<td><a href={relatedFile['@id'] || ''}>{relatedFile.accession || relatedFile.uuid || relatedFile['@id']}</a></td>);
+                fileTwo.push(<td>{relatedFile.file_format}</td>);
+                fileTwo.push(<td></td>);
+            }
+        }
+        return(
+            <tbody>
+                <tr className='expset-sublist-entry'>
+                    {file['@id'] ?
+                        <td rowSpan="2" className="expset-exp-cell expset-checkbox-cell">
+                            <Checkbox validationState='warning' checked={this.state.checked} name="file-checkbox" id={fileID} className='expset-checkbox-sub' onChange={this.handleCheck}/>
+                        </td>
+                    : <td rowSpan="2"></td>
+                    }
+                    <td rowSpan="2" className="expset-exp-cell expset-exp-accession-title-cell">
+                        <a href={
+                            info['@id']  ? info['@id'] :
+                            info['accession'] ? '/experiments/' + info['accession'] :
+                            '#'
+                        }>
+                            {info.accession || info.uuid}
+                        </a>
+                    </td>
+                    <td rowSpan="2" className="expset-exp-cell">
+                        <a href={info.biosample_id || ''}>
+                            {info.biosample}
+                        </a>
+                    </td>
+                    {(fileOne && fileOne[0]) ? fileOne[0] : null}
+                    {(fileOne && fileOne[1]) ? fileOne[1] : null}
+                    {(fileOne && fileOne[2]) ? fileOne[2] : null}
+                </tr>
+                {fileTwo ?
+                <tr>
+                    {fileTwo[0]}
+                    {fileTwo[1]}
+                    {fileTwo[2]}
+                </tr>
+                : null}
+            </tbody>
+        );
+    }
+});

--- a/src/encoded/static/components/experiments-table.js
+++ b/src/encoded/static/components/experiments-table.js
@@ -34,7 +34,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
     },
 
     getInitialState: function() {
-    	return {
+        return {
             checked: true,
             selectedFiles: new Set()
         };
@@ -82,10 +82,11 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
 
         // Let parentController control 'checked' state if provided.
         // Fallback to own state otherwise.
+        var checked;
         if (this.props.parentController) {
-            var checked = this.props.parentController.state.checked;
+            checked = this.props.parentController.state.checked;
         } else {
-            var checked = this.state.checked;
+            checked = this.state.checked;
         }
 
         var childFileEntryRows = Object.keys(fileDetail).map(function (file) {
@@ -141,7 +142,7 @@ var getFileDetailContainer = module.exports.getFileDetailContainer = function(ex
                 'uuid':         experimentArray[i].uuid,
                 '@id' :         experimentArray[i]['@id']
                 // Still missing : 'data', 'related'
-            }
+            };
 
             if(experimentArray[i].files){
                 tempFiles = experimentArray[i].files;
@@ -163,7 +164,8 @@ var getFileDetailContainer = module.exports.getFileDetailContainer = function(ex
             if(tempFiles.length > 0){
                 var relatedFiles = {};
                 var relatedData = [];
-                for(var k=0;k<tempFiles.length;k++){
+                var k;
+                for(k=0;k<tempFiles.length;k++){
 
                     // only use first file relation for now. Only support one relationship total
                     if(tempFiles[k].related_files && tempFiles[k].related_files[0].file){
@@ -184,7 +186,7 @@ var getFileDetailContainer = module.exports.getFileDetailContainer = function(ex
                     }
                 }
                 var usedRelations = [];
-                for(var k=0;k<tempFiles.length;k++){
+                for(k=0;k<tempFiles.length;k++){
                     if(_.contains(Object.keys(relatedFiles), tempFiles[k]['@id'])){
                         if(_.contains(usedRelations, tempFiles[k]['@id'])){
                             // skip already-added related files

--- a/src/encoded/static/components/experiments-table.js
+++ b/src/encoded/static/components/experiments-table.js
@@ -14,9 +14,6 @@ var _ = require('underscore');
  * of "selectedFiles" Set and "checked", for integration with other pages/UI.
  */
 
-// TODO (ideally): Functionality to customize columns (e.g. pass in a schema instead of list of 
-// column names, arrange fields appropriately under them).
-
 var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
 
     propTypes : {
@@ -207,6 +204,9 @@ var getFileDetailContainer = module.exports.getFileDetailContainer = function(ex
 
 var FileEntry = React.createClass({
 
+    // TODO (ideally): Functionality to customize columns (e.g. pass in a schema instead of list of 
+    // column names, arrange fields appropriately under them).
+
     getInitialState: function() {
         return {
             checked: true
@@ -274,19 +274,17 @@ var FileEntry = React.createClass({
                     f.push(<td><a href={file['@id'] || ''}>{file.accession || file.uuid || file['@id']}</a></td>);
                 }
 
+                if (!exists) { 
+                    f.push(<td></td>);
+                    continue;
+                }
+
                 if (columnHeadersShortened[i] == 'File Type'){
-                    if (!exists) { 
-                        f.push(<td></td>);
-                        continue;
-                    } 
                     f.push(<td>{file.file_format}</td>);
+                    continue;
                 }
 
                 if (columnHeadersShortened[i] == 'File Info'){
-                    if (!exists) { 
-                        f.push(<td></td>);
-                        continue;
-                    } 
                     if (paired) {
                         f.push(<td>Paired end {file.paired_end}</td>);
                     } else if (file.file_format === 'fastq' || file.file_format === 'fasta') {
@@ -294,6 +292,7 @@ var FileEntry = React.createClass({
                     } else {
                         f.push(<td></td>);
                     }
+                    continue;
                 }
             }
             return f;

--- a/src/encoded/static/components/experiments-table.js
+++ b/src/encoded/static/components/experiments-table.js
@@ -14,6 +14,9 @@ var _ = require('underscore');
  * of "selectedFiles" Set and "checked", for integration with other pages/UI.
  */
 
+// TODO (ideally): Functionality to customize columns (e.g. pass in a schema instead of list of 
+// column names, arrange fields appropriately under them).
+
 var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
 
     propTypes : {


### PR DESCRIPTION
@j1z0 @carlvitzthum 
Ready for master (I think) (to pull in updated version) & works well on Browse page (same functionality/appearance as before); may edit `experiments-table.js` further to integrate with exp-set page (likely on branch FF-314 instd. of this one).

Moved out code related to experiments/files' data fitting into table into new component (and file) `ExperimentsTable`. Tiny amount of refactoring for comprehensibility. The `experiments-table.js` module now also contains a function `getFileDetailContainer` which houses Carl's code related to parsing experiment/file data for table that may be imported to other modules/component. `ExperimentsTable` performs same actions as ExperimentSet/ExperimentSetRow previously did in terms of setting state of `selectedFiles`, but also allows to supply a `parentController` react element (via `parentController={this}` where `this` is the parent component's reference to itself so that the parentController may be used to manage state (state.checked, state.selectedFiles) for integration with Browse view & checkboxes and similar functionality later on Exp-Set page.