### PR TITLE
Webpack adjustment

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,36 +10,36 @@ gulp.task('build', ['set-production', 'webpack']);
 gulp.task('build-quick', ['set-quick', 'webpack']);
 
 gulp.task('set-production', [], function () {
-  process.env.NODE_ENV = 'production';
+    process.env.NODE_ENV = 'production';
 });
 
 gulp.task('set-quick', [], function () {
-  process.env.NODE_ENV = 'quick';
+    process.env.NODE_ENV = 'quick';
 });
 
 gulp.task('set-quick-uglified', [], function () {
-  process.env.NODE_ENV = 'quick-uglified';
+    process.env.NODE_ENV = 'quick-uglified';
 });
 
 var webpackOnBuild = function (done) {
-  return function (err, stats) {
-    if (err) {
-      throw new gutil.PluginError("webpack", err);
-    }
-    gutil.log("[webpack]", stats.toString({
-      colors: true
-    }));
-    gutil.log("Build Completed"); // Gives (useful) time after each completed compile
-    if (done) { done(err); }
-  };
+    return function (err, stats) {
+        if (err) {
+            throw new gutil.PluginError("webpack", err);
+        }
+        gutil.log("[webpack]", stats.toString({
+            colors: true
+        }));
+        gutil.log("Build Completed"); // Gives (useful) time after each completed compile
+        if (done) { done(err); }
+    };
 };
 
 gulp.task('webpack', [], function (cb) {
-  var webpackConfig = require('./webpack.config.js');
-  webpack(webpackConfig).run(webpackOnBuild(cb));
+    var webpackConfig = require('./webpack.config.js');
+    webpack(webpackConfig).run(webpackOnBuild(cb));
 });
 
 gulp.task('watch', [], function (cb) {
-  var webpackConfig = require('./webpack.config.js');
-  webpack(webpackConfig).watch(300, webpackOnBuild());
+    var webpackConfig = require('./webpack.config.js');
+    webpack(webpackConfig).watch(300, webpackOnBuild());
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var webpack = require('webpack');
 
 gulp.task('default', ['webpack', 'watch']);
 gulp.task('dev', ['default']);
+gulp.task('dev-uglified', ['set-quick-uglified','default']);
 gulp.task('build', ['set-production', 'webpack']);
 gulp.task('build-quick', ['set-quick', 'webpack']);
 
@@ -16,7 +17,12 @@ gulp.task('set-quick', [], function () {
   process.env.NODE_ENV = 'quick';
 });
 
+gulp.task('set-quick-uglified', [], function () {
+  process.env.NODE_ENV = 'quick-uglified';
+});
+
 var webpackOnBuild = function (done) {
+  var date = new Date();
   return function (err, stats) {
     if (err) {
       throw new gutil.PluginError("webpack", err);
@@ -24,6 +30,7 @@ var webpackOnBuild = function (done) {
     gutil.log("[webpack]", stats.toString({
       colors: true
     }));
+    gutil.log("Build Completed"); // Gives (useful) time after each completed compile
     if (done) { done(err); }
   };
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,6 @@ gulp.task('set-quick-uglified', [], function () {
 });
 
 var webpackOnBuild = function (done) {
-  var date = new Date();
   return function (err, stats) {
     if (err) {
       throw new gutil.PluginError("webpack", err);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test": "jest",
     "build": "gulp build",
     "build-quick": "gulp build-quick",
-    "dev": "gulp dev"
+    "dev": "gulp dev",
+    "dev-uglified" : "gulp dev-uglified"
   },
   "author": "",
   "license": "MIT",

--- a/src/encoded/static/browser.js
+++ b/src/encoded/static/browser.js
@@ -26,16 +26,18 @@ function mapStateToProps(store) {
 // Treat domready function as the entry point to the application.
 // Inside this function, kick-off all initialization, everything up to this
 // point should be definitions.
-if (!window.TEST_RUNNER) domready(function ready() {
-    console.log('ready');
-    // Set <html> class depending on browser features
-    var BrowserFeat = require('./components/browserfeat').BrowserFeat;
-    BrowserFeat.setHtmlFeatClass();
+if (window && window.document && !window.TEST_RUNNER) domready(function ready() {
+    console.log('Browser: ready');
+
     App.getRenderedProps(document);
     var server_stats = require('querystring').parse(window.stats_cookie);
     App.recordServerStats(server_stats, 'html');
     var UseApp = connect(mapStateToProps)(App);
     var app = ReactDOM.render(<Provider store={store}><UseApp /></Provider>, document);
+
+    // Set <html> class depending on browser features
+    var BrowserFeat = require('./components/browserfeat').BrowserFeat;
+    BrowserFeat.setHtmlFeatClass();
 
     // Simplify debugging
     window.app = app;

--- a/src/encoded/static/inline.js
+++ b/src/encoded/static/inline.js
@@ -4,8 +4,8 @@
 // require.ensure creates & append to <head> a <script src="/static/build/bundle.[chunkName].js" ...> element
 // consisting of compilation from libs/compat.js and browser.js
 require.ensure(['./libs/compat', './browser'], function(require) {
-	require('./libs/compat');  // Shims first
-	require('./browser');
+    require('./libs/compat');  // Shims first
+    require('./browser');
 }, 'bundle');
 
 // Read and clear stats cookie
@@ -18,15 +18,15 @@ cookie.set('X-Stats', '', {path: '/', expires: new Date(0)});
 window.onload = function () {
     window._onload_event_fired = true;
 
-	// Delay non-React script execution until clientside app is mounted (hopefully).
-	setTimeout(function(){
-		// Use a separate tracker for dev / test
-		var ga = require('google-analytics');
-		var trackers = {'www.encodeproject.org': 'UA-47809317-1'};
-		var tracker = trackers[document.location.hostname] || 'UA-47809317-2';
-		ga('create', tracker, {'cookieDomain': 'none', 'siteSpeedSampleRate': 100});
-		ga('send', 'pageview');
-	}, 0);
+    // Delay non-React script execution until clientside app is mounted (hopefully).
+    setTimeout(function(){
+        // Use a separate tracker for dev / test
+        var ga = require('google-analytics');
+        var trackers = {'www.encodeproject.org': 'UA-47809317-1'};
+        var tracker = trackers[document.location.hostname] || 'UA-47809317-2';
+        ga('create', tracker, {'cookieDomain': 'none', 'siteSpeedSampleRate': 100});
+        ga('send', 'pageview');
+    }, 0);
 };
 
 // Not Used

--- a/src/encoded/static/inline.js
+++ b/src/encoded/static/inline.js
@@ -1,28 +1,35 @@
 'use strict';
 
+// Load the rest of the app as a separate chunk. 
+// require.ensure creates & append to <head> a <script src="/static/build/bundle.[chunkName].js" ...> element
+// consisting of compilation from libs/compat.js and browser.js
+require.ensure(['./libs/compat', './browser'], function(require) {
+	require('./libs/compat');  // Shims first
+	require('./browser');
+}, 'bundle');
+
 // Read and clear stats cookie
 var cookie = require('cookie-monster')(document);
 window.stats_cookie = cookie.get('X-Stats') || '';
 cookie.set('X-Stats', '', {path: '/', expires: new Date(0)});
 
-// Use a separate tracker for dev / test
-var ga = require('google-analytics');
-var trackers = {'www.encodeproject.org': 'UA-47809317-1'};
-var tracker = trackers[document.location.hostname] || 'UA-47809317-2';
-ga('create', tracker, {'cookieDomain': 'none', 'siteSpeedSampleRate': 100});
-ga('send', 'pageview');
 
 // Need to know if onload event has fired for safe history api usage.
 window.onload = function () {
     window._onload_event_fired = true;
+
+	// Delay non-React script execution until clientside app is mounted (hopefully).
+	setTimeout(function(){
+		// Use a separate tracker for dev / test
+		var ga = require('google-analytics');
+		var trackers = {'www.encodeproject.org': 'UA-47809317-1'};
+		var tracker = trackers[document.location.hostname] || 'UA-47809317-2';
+		ga('create', tracker, {'cookieDomain': 'none', 'siteSpeedSampleRate': 100});
+		ga('send', 'pageview');
+	}, 0);
 };
 
-var $script = require('scriptjs');
-$script.path('/static/build/');
+// Not Used
+//var $script = require('scriptjs');
+//$script.path('/static/build/');
 //$script('https://login.persona.org/include.js', 'persona');
-
-// Load the rest of the app as a separate chunk.
-require.ensure(['./libs/compat', './browser'], function(require) {
-	require('./libs/compat');  // Shims first
-	require('./browser');
-}, 'bundle');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,13 @@ if (env === 'production') {
 	// add chunkhash to chunk names for production only (it's slower)
 	chunkFilename = '[name].[chunkhash].js';
 	sourceMapType = 'source-map';
+} else if (env === 'quick-uglified') {
+	// Uglify JS for dev as well on task 'npm run dev-uglified' - 
+	// slightly slower but reduces invariant violations where
+	// client-side render != server-side reason (*perhaps* allowing clientside JS to exec faster)
+	// set 'beautify : true' to get nicer output (whitespace, linebreaks) for debugging.
+	plugins.push(new webpack.optimize.UglifyJsPlugin({compress: false, mangle: false}));
+	sourceMapType = 'source-map';
 }
 
 var preLoaders = [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,8 @@ var webpack = require('webpack');
 var env = process.env.NODE_ENV;
 
 var PATHS = {
-	static: path.resolve(__dirname, 'src/encoded/static'),
-	build: path.resolve(__dirname, 'src/encoded/static/build'),
+    static: path.resolve(__dirname, 'src/encoded/static'),
+    build: path.resolve(__dirname, 'src/encoded/static/build'),
 };
 
 var plugins = [];
@@ -14,103 +14,103 @@ var chunkFilename = '[name].js';
 var sourceMapType = null;
 
 if (env === 'production') {
-	// tell react to use production build
-	plugins.push(new webpack.DefinePlugin({
-      'process.env': {
-        'NODE_ENV': '"production"'
-      }
-   }));
-	// uglify code for production
-	plugins.push(new webpack.optimize.UglifyJsPlugin({minimize: true}));
-	// add chunkhash to chunk names for production only (it's slower)
-	chunkFilename = '[name].[chunkhash].js';
-	sourceMapType = 'source-map';
+    // tell react to use production build
+    plugins.push(new webpack.DefinePlugin({
+        'process.env': {
+            'NODE_ENV': '"production"'
+        }
+    }));
+    // uglify code for production
+    plugins.push(new webpack.optimize.UglifyJsPlugin({minimize: true}));
+    // add chunkhash to chunk names for production only (it's slower)
+    chunkFilename = '[name].[chunkhash].js';
+    sourceMapType = 'source-map';
 } else if (env === 'quick-uglified') {
-	// Uglify JS for dev as well on task 'npm run dev-uglified' - 
-	// slightly slower but reduces invariant violations where
-	// client-side render != server-side reason (*perhaps* allowing clientside JS to exec faster)
-	// set 'beautify : true' to get nicer output (whitespace, linebreaks) for debugging.
-	plugins.push(new webpack.optimize.UglifyJsPlugin({compress: false, mangle: false}));
-	sourceMapType = 'source-map';
+    // Uglify JS for dev as well on task 'npm run dev-uglified' - 
+    // slightly slower but reduces invariant violations where
+    // client-side render != server-side reason (*perhaps* allowing clientside JS to exec faster)
+    // set 'beautify : true' to get nicer output (whitespace, linebreaks) for debugging.
+    plugins.push(new webpack.optimize.UglifyJsPlugin({compress: false, mangle: false}));
+    sourceMapType = 'source-map';
 }
 
 var preLoaders = [
-	// Strip @jsx pragma in react-forms, which makes babel abort
-	{
-		test: /\.js$/,
-		loader: 'string-replace',
-		query: {
-			search: '@jsx',
-			replace: 'jsx',
-		}
-	}
+    // Strip @jsx pragma in react-forms, which makes babel abort
+    {
+        test: /\.js$/,
+        loader: 'string-replace',
+        query: {
+            search: '@jsx',
+            replace: 'jsx',
+        }
+    }
 ];
 
 var loaders = [
-	// add babel to load .js files as ES6 and transpile JSX
-	{
-		test: /\.js$/,
-		include: [
-			path.resolve(__dirname, 'src/encoded/static'),
-		],
-		loader: 'babel',
-	},
-	{
-		test: /\.json$/,
-		loader: 'json',
-	}
+    // add babel to load .js files as ES6 and transpile JSX
+    {
+        test: /\.js$/,
+        include: [
+            path.resolve(__dirname, 'src/encoded/static'),
+        ],
+        loader: 'babel',
+    },
+    {
+        test: /\.json$/,
+        loader: 'json',
+    }
 ];
 
 module.exports = [
-	// for browser
-	{
-		context: PATHS.static,
-		entry: {inline: './inline'},
-		output: {
-			path: PATHS.build,
-			publicPath: '/static/build/',
-			filename: '[name].js',
-			chunkFilename: chunkFilename,
-		},
-		module: {
-			preLoaders: preLoaders,
-			loaders: loaders,
-		},
-		devtool: sourceMapType,
-		plugins: plugins,
-		debug: true
-	},
-	// for server-side rendering
-	{
-		entry: {
-			renderer: './src/encoded/static/server.js',
-		},
-		target: 'node',
-		// make sure compiled modules can use original __dirname
-		node: {
-			__dirname: true,
-		},
-		externals: [
-			'brace',
-			'brace/mode/json',
-			'brace/theme/solarized_light',
-			'd3',
-			'dagre-d3',
-			// avoid bundling babel transpiler, which is not used at runtime
-			'babel-core/register',
-		],
-		output: {
-			path: PATHS.build,
-			filename: '[name].js',
-			libraryTarget: 'commonjs2',
-			chunkFilename: chunkFilename,
-		},
-		module: {
-			preLoaders: preLoaders,
-			loaders: loaders,
-		},
-		devtool: sourceMapType,
-		plugins: plugins,
-		debug: true
-	}
+    // for browser
+    {
+        context: PATHS.static,
+        entry: {inline: './inline'},
+        output: {
+            path: PATHS.build,
+            publicPath: '/static/build/',
+            filename: '[name].js',
+            chunkFilename: chunkFilename,
+        },
+        module: {
+            preLoaders: preLoaders,
+            loaders: loaders,
+        },
+        devtool: sourceMapType,
+        plugins: plugins,
+        debug: true
+    },
+    // for server-side rendering
+    {
+        entry: {
+            renderer: './src/encoded/static/server.js',
+        },
+        target: 'node',
+        // make sure compiled modules can use original __dirname
+        node: {
+            __dirname: true,
+        },
+        externals: [
+            'brace',
+            'brace/mode/json',
+            'brace/theme/solarized_light',
+            'd3',
+            'dagre-d3',
+            // avoid bundling babel transpiler, which is not used at runtime
+            'babel-core/register',
+        ],
+        output: {
+            path: PATHS.build,
+            filename: '[name].js',
+            libraryTarget: 'commonjs2',
+            chunkFilename: chunkFilename,
+        },
+        module: {
+            preLoaders: preLoaders,
+            loaders: loaders,
+        },
+        devtool: sourceMapType,
+        plugins: plugins,
+        debug: true
+    }
 ];


### PR DESCRIPTION
npm run dev-uglified for a JS watch compile script that additionally passes output JS through fast/barebones-configured Uglify webpack plugin. First time compile on `npm run dev-uglified` (or `npm run dev` for that matter) takes 10-20 seconds, however subsequent runs (on detecting changed files) takes only a second or too. 